### PR TITLE
FindTxnResponse: `txn` is nil when response invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- FindTxnResponse: `txn` is nil (no longer raises exception) when the response is invalid
+
 ## [0.3.0] - 2017-03-27
 ### Changed
 - Work with new version of BloomNet Center

--- a/lib/bloom_net_center_client/responses/txn_response.rb
+++ b/lib/bloom_net_center_client/responses/txn_response.rb
@@ -6,10 +6,13 @@ module BloomNetCenterClient
     private
 
     def default_txn
+      attribute_params = body[:data][:attributes]
+      return nil if attribute_params.nil?
+
       attributes = Txn::ATTRS.each_with_object({}) do |attr, hash|
         attr_dasherized = attr.to_s.dasherize
         hash[attr] = body[:data][attr_dasherized] ||
-          body[:data][:attributes][attr_dasherized]
+          attribute_params[attr_dasherized]
       end
       BloomNetCenterClient::Txn.new(attributes)
     end

--- a/spec/lib/bloom_net_center_client/responses/txn_response_spec.rb
+++ b/spec/lib/bloom_net_center_client/responses/txn_response_spec.rb
@@ -13,54 +13,63 @@ module BloomNetCenterClient
     end
 
     describe "#txn" do
-      let(:body) do
-        {
-          "data" => {
-            "id" => "tracking",
-            "type" => "txns",
-            "attributes" => {
-              "sender-first-name" => "Fatima",
-              "sender-last-name" => "Roberto",
-              "sender-street" => "24 Lilian St",
-              "sender-city" => "Sum City",
-              "sender-province" => "Sum Province",
-              "sender-contact-number" => "+639171234567",
-              "recipient-first-name" => "Mike",
-              "recipient-last-name" => "Roberto",
-              "recipient-street" => "33 Up St",
-              "recipient-city" => "Upcity",
-              "recipient-province" => "Uprovince",
-              "recipient-contact-number" => "+638188927288",
-              "currency" => "PHP",
-              "amount" => "2050.0",
-              "account" => "GATX",
-              "status" => "unfunded",
+      context "there is a valid response" do
+        let(:body) do
+          {
+            "data" => {
+              "id" => "tracking",
+              "type" => "txns",
+              "attributes" => {
+                "sender-first-name" => "Fatima",
+                "sender-last-name" => "Roberto",
+                "sender-street" => "24 Lilian St",
+                "sender-city" => "Sum City",
+                "sender-province" => "Sum Province",
+                "sender-contact-number" => "+639171234567",
+                "recipient-first-name" => "Mike",
+                "recipient-last-name" => "Roberto",
+                "recipient-street" => "33 Up St",
+                "recipient-city" => "Upcity",
+                "recipient-province" => "Uprovince",
+                "recipient-contact-number" => "+638188927288",
+                "currency" => "PHP",
+                "amount" => "2050.0",
+                "account" => "GATX",
+                "status" => "unfunded",
+              }
             }
           }
-        }
-      end
-      let(:response) { described_class.new(body: body) }
-      let(:txn) { response.txn }
+        end
+        let(:response) { described_class.new(body: body) }
+        let(:txn) { response.txn }
 
-      it "builds a Txn out of the response" do
-        expect(txn).to be_a Txn
-        expect(txn.id).to eq "tracking"
-        expect(txn.sender_first_name).to eq "Fatima"
-        expect(txn.sender_last_name).to eq "Roberto"
-        expect(txn.sender_street).to eq "24 Lilian St"
-        expect(txn.sender_city).to eq "Sum City"
-        expect(txn.sender_province).to eq "Sum Province"
-        expect(txn.sender_contact_number).to eq "+639171234567"
-        expect(txn.recipient_first_name).to eq "Mike"
-        expect(txn.recipient_last_name).to eq "Roberto"
-        expect(txn.recipient_street).to eq "33 Up St"
-        expect(txn.recipient_city).to eq "Upcity"
-        expect(txn.recipient_province).to eq "Uprovince"
-        expect(txn.recipient_contact_number).to eq "+638188927288"
-        expect(txn.currency).to eq "PHP"
-        expect(txn.amount).to eq 2050.0
-        expect(txn.account).to eq "GATX"
-        expect(txn.status).to eq "unfunded"
+        it "builds a Txn out of the response" do
+          expect(txn).to be_a Txn
+          expect(txn.id).to eq "tracking"
+          expect(txn.sender_first_name).to eq "Fatima"
+          expect(txn.sender_last_name).to eq "Roberto"
+          expect(txn.sender_street).to eq "24 Lilian St"
+          expect(txn.sender_city).to eq "Sum City"
+          expect(txn.sender_province).to eq "Sum Province"
+          expect(txn.sender_contact_number).to eq "+639171234567"
+          expect(txn.recipient_first_name).to eq "Mike"
+          expect(txn.recipient_last_name).to eq "Roberto"
+          expect(txn.recipient_street).to eq "33 Up St"
+          expect(txn.recipient_city).to eq "Upcity"
+          expect(txn.recipient_province).to eq "Uprovince"
+          expect(txn.recipient_contact_number).to eq "+638188927288"
+          expect(txn.currency).to eq "PHP"
+          expect(txn.amount).to eq 2050.0
+          expect(txn.account).to eq "GATX"
+          expect(txn.status).to eq "unfunded"
+        end
+      end
+
+      context "there is an invalid response" do
+        let(:body) { { "data" => { } } }
+        let(:response) { described_class.new(body: body) }
+        subject(:txn) { response.txn }
+        it { is_expected.to be_nil }
       end
     end
 


### PR DESCRIPTION
It no longer raises an exception

fixes [#4]